### PR TITLE
Update run.sh for KVM support

### DIFF
--- a/HassOsEnableSSH/run.sh
+++ b/HassOsEnableSSH/run.sh
@@ -6,9 +6,9 @@ key=$(cat options.json |jq -r '.SSHKey')
 until false; do
 set +e
   mkdir /tmp 2>/dev/null
-  mkdir /tmp/mmcblk0p1 /tmp/sda1 /tmp/sdb1 /tmp/nvme0n1p1 2> /dev/null
-  if [ ! -e /dev/sda1 ] && [ ! -e /dev/mmcblk0p1 ] && [ ! -e /dev/sdb1 ] && [ ! -e /dev/nvme0n1p1 ] ; then 
-    echo "nothing to do. I can't find a /dev/sda1, /dev/sdb1, /dev/mmcblk0p1 or /dev/nvme0n1p1";
+  mkdir /tmp/vda1 /tmp/mmcblk0p1 /tmp/sda1 /tmp/sdb1 /tmp/nvme0n1p1 2> /dev/null
+  if [ ! -e /dev/sda1 ] && [ ! -e /dev/vda1 ] && [ ! -e /dev/mmcblk0p1 ] && [ ! -e /dev/sdb1 ] && [ ! -e /dev/nvme0n1p1 ] ; then 
+    echo "nothing to do. I can't find a /dev/vda1, /dev/sda1, /dev/sdb1, /dev/mmcblk0p1 or /dev/nvme0n1p1";
     while true; do sleep 99999; done;
   fi;
 
@@ -28,6 +28,7 @@ set +e
     fi
   }
 
+  performWork vda1
   performWork sda1
   performWork sdb1
   performWork mmcblk0p1


### PR DESCRIPTION
This PR was tested with Libvirt/KVM assuming that Home Assistant OS is the only disk attached to the VM.

This disk type is the native VirtIO disk which is the default when creating KVM machines. This should add support for KVM. I have confirmed it working in my environment which is a KVM Home Assistant OS instance with a single HDD attached to it