### PR TITLE
Replace the default pubkey with a clearly bogus key

### DIFF
--- a/HassOsEnableSSH/config.json
+++ b/HassOsEnableSSH/config.json
@@ -1,6 +1,6 @@
 {
   "name": "HassOS SSH port 22222 Configurator",
-  "version": "0.9.1a",
+  "version": "0.9.2b",
   "slug": "hassos_ssh_configurator_addon",
   "description": "This enables the SSH HassOS Console on port 22222. Only for Home Assistant OS.",
   "arch": ["amd64", "i386", "armhf", "armv7", "aarch64"],
@@ -14,7 +14,7 @@
   "privileged": ["SYS_ADMIN"],
   "full_access": true,
   "options": {
-    "SSHKey": "Insert the full contents (i.e. ssh-rsa AAA...) of your public ssh key (id_rsa.pub, id_ecdsa.pub, ...) here."
+    "SSHKey": "ssh-rsa AAA.. Insert the full contents (i.e. ssh-rsa AAA...) of your public ssh key (id_rsa.pub, id_ecdsa.pub, ...) here."
   },
   "schema": {
     "SSHKey": "str"

--- a/HassOsEnableSSH/config.json
+++ b/HassOsEnableSSH/config.json
@@ -14,7 +14,7 @@
   "privileged": ["SYS_ADMIN"],
   "full_access": true,
   "options": {
-    "SSHKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDGTlRAfhm9BIV6l6sOubRgeCY0wRhYQVfB3QBWFl2ELpeAnTHwRYY+4pSP1Nu7FuZqAzDyZkssmFkbXHJGqi6EAnAkRLsKhzvDKo5WSXfEQdl2kSN5bgU/e37GfwqG4ChEfY56gwu+tdHtt4eIrzKpmUKqFZWJaGoeI9sHptQR9QNitEsm0krkOcK0VLFLTeau+HOO1A4plcLjBB9Y43SFjth/Ouke+DVGaBO2LYNc8U0S4EiHT6KdRXS4iIwYjXMw6SEsT7eP9IWQObQ4ZgyG0cHO/6ArxJ0fyOcAI29sLzM9466ID0mTaJWHriTRf6Lxhpdd/S30VTG0JMTdo/Fj root@HLAB-A17"
+    "SSHKey": "ssh-rsa AAAAB3NzaEXAMPLEexampleEXAMPLEexample/S30VTG0JMTdo/Fj root@example
   },
   "schema": {
     "SSHKey": "str"

--- a/HassOsEnableSSH/config.json
+++ b/HassOsEnableSSH/config.json
@@ -14,7 +14,7 @@
   "privileged": ["SYS_ADMIN"],
   "full_access": true,
   "options": {
-    "SSHKey": "ssh-rsa AAAAB3NzaEXAMPLEexampleEXAMPLEexample/S30VTG0JMTdo/Fj root@example
+    "SSHKey": "Insert the full contents (i.e. ssh-rsa AAA...) of your public ssh key (id_rsa.pub, id_ecdsa.pub, ...) here."
   },
   "schema": {
     "SSHKey": "str"


### PR DESCRIPTION
Since it's impossible to verify whether or not the default pubkey is tied to a key controlled by the author, this makes it clear no real key is being used by default, and also makes it more obvious the default value should be changed for people less familiar with how SSH keys work.