### PR TITLE
Fix build error in latest HAOS

### DIFF
--- a/Pi4EnableI2C/Dockerfile
+++ b/Pi4EnableI2C/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILD_FROM
-FROM $BUILD_FROM
+ARG BUILD_FROM=ghcr.io/home-assistant/base:latest
+FROM ${BUILD_FROM}
 ENV LANG C.UTF-8
 COPY run.sh /
 WORKDIR /data


### PR DESCRIPTION
BUILD_FROM argument requirements have changed in the latest version of HAOS. Add-on/App will no longer build unless this parameter is explicitly set in DOCKERFILE.