### PR TITLE
Set default value for BUILD_FROM in Dockerfile

### DIFF
--- a/Run/Dockerfile
+++ b/Run/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM
+ARG BUILD_FROM=ghcr.io/home-assistant/base:latest
 FROM $BUILD_FROM
 ENV LANG C.UTF-8
 COPY run.sh /


### PR DESCRIPTION
Similar changes to https://github.com/adamoutler/HassOSConfigurator/pull/55

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Container deployment now works with default configuration settings, reducing the need for external build parameter specification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamoutler/HassOSConfigurator/pull/58)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->